### PR TITLE
fix error

### DIFF
--- a/flask_script/__init__.py
+++ b/flask_script/__init__.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 import argparse
 
 from flask import Flask
-from flask._compat import text_type
+from flask_script._compat import text_type
 
 from ._compat import iteritems
 from .commands import Group, Option, Command, Server, Shell


### PR DESCRIPTION
Solution for "ModuleNotFoundError: No module named 'flask._compat' ".